### PR TITLE
Add django_id attribute to identity document

### DIFF
--- a/flag_engine/identities/builders.py
+++ b/flag_engine/identities/builders.py
@@ -1,14 +1,15 @@
 import typing
 
 from flag_engine.identities.models import IdentityModel
-from flag_engine.identities.schemas import IdentitySchema
+from flag_engine.identities.schemas import IdentitySchemaDump, IdentitySchemaLoad
 
-identity_schema = IdentitySchema()
+identity_schema_load = IdentitySchemaLoad()
+identity_schema_dump = IdentitySchemaDump()
 
 
 def build_identity_dict(identity_obj: typing.Any) -> dict:
-    return identity_schema.dump(identity_obj)
+    return identity_schema_dump.dump(identity_obj)
 
 
 def build_identity_model(identity_obj: typing.Any) -> IdentityModel:
-    return identity_schema.load(build_identity_dict(identity_obj))
+    return identity_schema_load.load(build_identity_dict(identity_obj))

--- a/flag_engine/identities/schemas.py
+++ b/flag_engine/identities/schemas.py
@@ -17,9 +17,8 @@ class TraitSchema(LoadToModelSchema):
         model_class = TraitModel
 
 
-class IdentitySchema(LoadToModelSchema):
+class IdentitySchemaLoad(LoadToModelSchema):
     identifier = fields.Str()
-    composite_key = fields.Str(dump_only=True)
     created_date = fields.Method(
         serialize="serialize_created_date",
         deserialize="deserialize_created_date",
@@ -36,7 +35,6 @@ class IdentitySchema(LoadToModelSchema):
     )
 
     class Meta:
-        # to exclude dump only fields, e.g: composite_key
         unknown = EXCLUDE
         model_class = IdentityModel
 
@@ -67,3 +65,12 @@ class IdentitySchema(LoadToModelSchema):
 
     def deserialize_created_date(self, created_date: str) -> datetime:
         return utils.from_iso_datetime(created_date)
+
+
+class IdentitySchemaDump(IdentitySchemaLoad):
+    class Meta:
+        unknown = EXCLUDE
+        model_class = IdentityModel
+
+    composite_key = fields.Str(dump_only=True)
+    django_id = fields.Int(required=False, attribute="id", dump_only=True)

--- a/tests/identities/test_identities_builders.py
+++ b/tests/identities/test_identities_builders.py
@@ -136,3 +136,4 @@ def test_build_identity_dict(django_identity):
     )
     assert isinstance(identity_dict, dict)
     assert json.dumps(identity_dict, cls=DecimalEncoder)
+    assert identity_dict["django_id"] == django_identity.id


### PR DESCRIPTION
Adds the django_id attribute to the identity document in case we need it in the future (for example if people complain that identities are receiving different values from the percentage split operator). 