### PR TITLE
fix(schema/load_to_model): allow model_class to be none

### DIFF
--- a/flag_engine/identities/schemas.py
+++ b/flag_engine/identities/schemas.py
@@ -1,6 +1,6 @@
 import typing
 
-from marshmallow import EXCLUDE, ValidationError, fields, post_dump
+from marshmallow import EXCLUDE, Schema, ValidationError, fields, post_dump
 
 from flag_engine.features.schemas import FeatureStateSchema
 from flag_engine.identities.models import IdentityModel, TraitModel
@@ -10,7 +10,7 @@ from flag_engine.utils.marshmallow.schemas import LoadToModelSchema
 from .constants import ACCEPTED_TRAIT_VALUE_TYPES, STRING, TRAIT_STRING_VALUE_MAX_LENGTH
 
 
-class TraitSchema(LoadToModelSchema):
+class BaseTraitSchema(Schema):
     trait_key = fields.Str()
     trait_value = fields.Method(
         serialize="serialize_trait_value",
@@ -35,6 +35,11 @@ class TraitSchema(LoadToModelSchema):
                 {TRAIT_STRING_VALUE_MAX_LENGTH} character"
             )
         return trait_value
+
+
+class TraitSchema(LoadToModelSchema, BaseTraitSchema):
+    class Meta:
+        model_class = TraitModel
 
 
 class IdentitySchemaLoad(LoadToModelSchema):

--- a/flag_engine/utils/marshmallow/schemas.py
+++ b/flag_engine/utils/marshmallow/schemas.py
@@ -7,10 +7,9 @@ class LoadToModelSchemaOpts(SchemaOpts):
         self.model_class = getattr(meta, "model_class", None)
 
 
-class LoadToModelSchema(Schema):
-    """Base schema class that returns a model instance if model_class option is set
-    on Meta class after loading(using post load hook)
-
+class LoadToModelMixin:
+    """A mixin class,  that returns a model instance (using model_class option set
+    on Meta class) after loading(using post load hook)
     Example usage:
 
     .. code-block:: python
@@ -18,17 +17,23 @@ class LoadToModelSchema(Schema):
         class AModel:
             id: int
 
-        class ASchema(LoadToModelSchema):
+        class ASchema(LoadToModelSchema, Schema):
             id = fields.Int()
 
             class Meta:
                 model_class = AModel
+
+
+
     """
 
     OPTIONS_CLASS = LoadToModelSchemaOpts
 
     @post_load()
     def make_instance(self, data, **kwargs) -> object:
-        if not self.opts.model_class:
-            return data
         return self.opts.model_class(**data)
+
+
+class LoadToModelSchema(LoadToModelMixin, Schema):
+    """Base schema class that uses LoadToModelMixin to create schema classes that
+    can be loaded to a model"""

--- a/flag_engine/utils/marshmallow/schemas.py
+++ b/flag_engine/utils/marshmallow/schemas.py
@@ -8,7 +8,8 @@ class LoadToModelSchemaOpts(SchemaOpts):
 
 
 class LoadToModelSchema(Schema):
-    """Base schema class that returns a model instance after loading(using post load hook)
+    """Base schema class that returns a model instance if model_class option is set
+    on Meta class after loading(using post load hook)
 
     Example usage:
 
@@ -29,5 +30,5 @@ class LoadToModelSchema(Schema):
     @post_load()
     def make_instance(self, data, **kwargs) -> object:
         if not self.opts.model_class:
-            raise ValueError("`model_class` attribute is not set in Meta class.")
+            return data
         return self.opts.model_class(**data)


### PR DESCRIPTION
A client can not inherit any schema whose parent is
LoadToModelSchema without setting up model_class
option in Meta class which is not the preferred
behavior, since some child just want
a dict instead of a class