### PR TITLE
Fix feature states serialization for segments

### DIFF
--- a/flag_engine/environments/models.py
+++ b/flag_engine/environments/models.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, field
 from flag_engine.environments.integrations.models import IntegrationModel
 from flag_engine.features.models import FeatureStateModel
 from flag_engine.projects.models import ProjectModel
-from flag_engine.segments.models import SegmentModel
 from flag_engine.utils.exceptions import FeatureStateNotFound
 
 
@@ -18,11 +17,6 @@ class EnvironmentModel:
     segment_config: IntegrationModel = None
     mixpanel_config: IntegrationModel = None
     heap_config: IntegrationModel = None
-
-    def get_segment(self, segment_id: int) -> SegmentModel:
-        return next(
-            filter(lambda segment: segment.id == segment_id, self.project.segments)
-        )
 
     def get_feature_state(self, feature_name: str) -> FeatureStateModel:
         try:

--- a/flag_engine/environments/schemas.py
+++ b/flag_engine/environments/schemas.py
@@ -25,7 +25,6 @@ class EnvironmentSchema(LoadToModelSchema):
         model_class = EnvironmentModel
 
     @pre_dump()
-    def add_segment_overrides(self, obj, *args, **kwargs):
-        if hasattr(obj, "feature_states"):
-            obj.segment_overrides = obj.feature_states
+    def set_environment_key_in_context(self, obj, *args, **kwargs):
+        self.context["environment_api_key"] = getattr(obj, "api_key", None)
         return obj

--- a/flag_engine/features/models.py
+++ b/flag_engine/features/models.py
@@ -35,7 +35,6 @@ class FeatureStateModel:
     feature: FeatureModel
     enabled: bool
     _value: typing.Any = field(default=None, init=False)
-    segment_id: int = None
     multivariate_feature_state_values: typing.List[
         MultivariateFeatureStateValueModel
     ] = field(default_factory=list)

--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -63,7 +63,9 @@ def mock_django_segment(mock_django_project, mock_django_feature):
 
 
 @pytest.fixture()
-def mock_django_environment(mock_django_project, mock_django_feature):
+def mock_django_environment(
+    mock_django_project, mock_django_feature, mock_django_segment
+):
     return DjangoEnvironment(
         id=1,
         project=mock_django_project,

--- a/tests/mock_django_classes.py
+++ b/tests/mock_django_classes.py
@@ -71,7 +71,9 @@ class DjangoSegmentRelatedObjectManager:
 
 class DjangoFeatureSegment:
     def __init__(self, feature_states: typing.List["DjangoFeatureState"] = None):
-        self.feature_states = DjangoFeatureStateRelatedManager(feature_states or [])
+        self.feature_states = DjangoFeatureSegmentFeatureStatesRelatedManager(
+            feature_states or []
+        )
 
 
 @dataclass
@@ -186,6 +188,15 @@ class DjangoFeatureStateRelatedManager:
 
     def all(self) -> typing.List[DjangoFeatureState]:
         return self.feature_states
+
+
+class DjangoFeatureSegmentFeatureStatesRelatedManager(DjangoFeatureStateRelatedManager):
+    def filter(self, **filter_kwargs) -> typing.List[DjangoFeatureState]:
+        if not filter_kwargs.get("environment__api_key"):
+            raise ValueError("Must provide environment__api_key filter arg")
+        return super(DjangoFeatureSegmentFeatureStatesRelatedManager, self).filter(
+            **filter_kwargs
+        )
 
 
 class DjangoEnvironment:

--- a/tests/unit/environments/test_environments_schemas.py
+++ b/tests/unit/environments/test_environments_schemas.py
@@ -1,0 +1,13 @@
+from flag_engine.environments.schemas import EnvironmentSchema
+
+
+def test_environment_schema_dump_sets_api_key_in_context(django_environment):
+    # Given
+    schema = EnvironmentSchema()
+
+    # When
+    environment_data = schema.dump(django_environment)
+
+    # Then
+    assert environment_data
+    assert schema.context.get("environment_api_key") == django_environment.api_key

--- a/tests/unit/segments/test_segments_schemas.py
+++ b/tests/unit/segments/test_segments_schemas.py
@@ -114,7 +114,6 @@ def test_dict_to_segment_model():
             {
                 "multivariate_feature_state_values": [],
                 "id": 1,
-                "segment_id": None,
                 "enabled": True,
                 "feature_state_value": None,
                 "feature": {"id": 1, "name": "my_feature", "type": "STANDARD"},

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -68,9 +68,7 @@ def test_identity_get_all_feature_states_segments_only(
 
     # but overridden to True for identities in the segment
     segment.feature_states.append(
-        FeatureStateModel(
-            id=4, feature=overridden_feature, enabled=True, segment_id=segment.id
-        )
+        FeatureStateModel(id=4, feature=overridden_feature, enabled=True)
     )
 
     # When


### PR DESCRIPTION
In moving to storing the segment overrides on the segments themselves, I hadn't considered the fact that the `feature_segments` attribute on the segment itself includes all the feature segments across all environments in the project that the segment lives. As such, we are serializing segments from other environments when we shouldn't be. 

This change fixes that but it's not the neatest, hence why I've added a bunch of comments. It's almost nudging me back to the original data model where the segment overrides were stored directly on the environment but I'm not sure. 