### PR TITLE
fix(identity/schema): use dump_default instead of default

### DIFF
--- a/flag_engine/identities/schemas.py
+++ b/flag_engine/identities/schemas.py
@@ -13,7 +13,7 @@ from .traits.schemas import TraitSchema
 class BaseIdentitySchema(Schema):
     identifier = fields.Str()
     created_date = fields.DateTime()
-    identity_uuid = fields.UUID(default=uuid.uuid4)
+    identity_uuid = fields.UUID(dump_default=uuid.uuid4)
     environment_api_key = fields.Str()
 
     @post_dump


### PR DESCRIPTION
since The 'default' argument to fields is deprecated. Use 'dump_default' instead