### PR TITLE
Allow custom identity schema

### DIFF
--- a/flag_engine/identities/builders.py
+++ b/flag_engine/identities/builders.py
@@ -1,11 +1,15 @@
+from marshmallow import Schema
+
 from flag_engine.identities.models import IdentityModel
 from flag_engine.identities.schemas import IdentitySchema
 
 identity_schema = IdentitySchema()
 
 
-def build_identity_dict(identity_model: IdentityModel) -> dict:
-    return identity_schema.dump(identity_model)
+def build_identity_dict(
+    identity_model: IdentityModel, schema: Schema = identity_schema
+) -> dict:
+    return schema.dump(identity_model)
 
 
 def build_identity_model(identity_dict: dict) -> IdentityModel:


### PR DESCRIPTION
This is a requirement so that we can pass in a custom schema in the Edge API when we dump an identity to dynamo since we need to convert any `float` trait values to `Decimal`. 