### PR TITLE
Feature/edge api 29/add integrations data property

### DIFF
--- a/flag_engine/environments/models.py
+++ b/flag_engine/environments/models.py
@@ -32,3 +32,22 @@ class EnvironmentModel:
     segment_config: IntegrationModel = None
     mixpanel_config: IntegrationModel = None
     heap_config: IntegrationModel = None
+
+    _INTEGRATION_ATTS = [
+        "amplitude_config",
+        "segment_config",
+        "mixpanel_config",
+        "heap_config",
+    ]
+
+    @property
+    def integrations_data(self) -> dict:
+        integrations_data = {}
+        for integration_attr in self._INTEGRATION_ATTS:
+            integration_config: IntegrationModel = getattr(self, integration_attr, None)
+            if integration_config:
+                integrations_data[integration_attr] = {
+                    "base_url": integration_config.base_url,
+                    "api_key": integration_config.api_key,
+                }
+        return integrations_data

--- a/flag_engine/environments/models.py
+++ b/flag_engine/environments/models.py
@@ -42,6 +42,19 @@ class EnvironmentModel:
 
     @property
     def integrations_data(self) -> dict:
+        """
+        Return a dictionary representation of all integration config objects.
+
+            e.g.
+            {
+                "mixpanel_configuration": {"base_url": None, "api_key": "some-key"},
+                "segment_configuration": {
+                    "base_url": "https://api.segment.com",
+                    "api_key": "some-key",
+                }
+            }
+        """
+
         integrations_data = {}
         for integration_attr in self._INTEGRATION_ATTS:
             integration_config: IntegrationModel = getattr(self, integration_attr, None)

--- a/tests/unit/environments/test_environments_models.py
+++ b/tests/unit/environments/test_environments_models.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 
+from flag_engine.environments.integrations.models import IntegrationModel
 from flag_engine.environments.models import EnvironmentAPIKeyModel
 
 
@@ -56,3 +57,31 @@ def test_environment_api_key_model_is_valid_is_false_for_non_expired_inactive_ke
         ).is_valid
         is False
     )
+
+
+def test_environment_integrations_data_returns_empty_dict_when_no_integrations(
+    environment,
+):
+    assert environment.integrations_data == {}
+
+
+def test_environment_integrations_data_returns_correct_data_when_multiple_integrations(
+    environment,
+):
+    # Given
+    example_key = "some-key"
+    segment_url = "https://api.segment.com"
+
+    environment.mixpanel_config = IntegrationModel(api_key=example_key)
+    environment.segment_config = IntegrationModel(
+        api_key=example_key, base_url=segment_url
+    )
+
+    # When
+    integrations_data = environment.integrations_data
+
+    # Then
+    assert integrations_data == {
+        "mixpanel_config": {"api_key": example_key, "base_url": None},
+        "segment_config": {"api_key": example_key, "base_url": segment_url},
+    }


### PR DESCRIPTION
Add a property to the environment model to generate a dictionary of integrations that can be used to pass to the integration handler service. 