### PR TITLE
fix(traits/float_value): Add custom field to ser/deser trait_value

### DIFF
--- a/flag_engine/identities/traits/schemas.py
+++ b/flag_engine/identities/traits/schemas.py
@@ -1,12 +1,30 @@
+import decimal
+
 from marshmallow import fields
 
 from flag_engine.identities.traits.models import TraitModel
 from flag_engine.utils.marshmallow.schemas import LoadToModelSchema
 
 
+class TraitValueField(fields.Field):
+    """Field that serializes float(and only float) to Decimal(because dynamodb can't understand float)
+    and deserializes Decimal(and only decimal) to float
+    """
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        if type(value) is float:
+            value = decimal.Decimal(str(value))
+        return value
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        if isinstance(value, decimal.Decimal):
+            value = float(value)
+        return value
+
+
 class TraitSchema(LoadToModelSchema):
     trait_key = fields.Str()
-    trait_value = fields.Field(allow_none=True)
+    trait_value = TraitValueField(allow_none=True)
 
     class Meta:
         model_class = TraitModel

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -190,6 +190,10 @@ def django_identity(
     django_enabled_feature_state_with_string_value,
     django_multivariate_feature_state,
     django_environment,
+    django_trait_integer,
+    django_trait_float,
+    django_trait_string,
+    django_trait_boolean,
 ):
     return DjangoIdentity(
         id=1,
@@ -200,5 +204,11 @@ def django_identity(
             django_enabled_feature_state,
             django_enabled_feature_state_with_string_value,
             django_multivariate_feature_state,
+        ],
+        identity_traits=[
+            django_trait_boolean,
+            django_trait_float,
+            django_trait_integer,
+            django_trait_string,
         ],
     )

--- a/tests/unit/identities/test_trait_schema.py
+++ b/tests/unit/identities/test_trait_schema.py
@@ -13,7 +13,6 @@ from flag_engine.identities.traits.schemas import TraitSchema
         ("key1", 21),
         ("key1", None),
         ("key1", 11.2),
-        ("key1", 11.2),
         ("key1", True),
     ),
 )
@@ -43,6 +42,7 @@ def test_trait_schema_load_converts_decimal_to_float():
 
     # Then
     assert trait_model.trait_value == trait_value
+    assert isinstance(trait_model.trait_value, float)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Since dynamodb can't understand float(and trait value can be float)
we need to convert it to Decimal in order to store that in dynamodb