### PR TITLE
fix: missing fs value in fs model dump

### DIFF
--- a/flag_engine/features/models.py
+++ b/flag_engine/features/models.py
@@ -38,13 +38,13 @@ class FeatureStateModel:
     enabled: bool
     django_id: int = None
     featurestate_uuid: str = field(default_factory=uuid.uuid4)
-    _value: typing.Any = field(default=None, init=False)
+    feature_state_value: typing.Any = field(default=None, init=False)
     multivariate_feature_state_values: typing.List[
         MultivariateFeatureStateValueModel
     ] = field(default_factory=list)
 
     def set_value(self, value: typing.Any):
-        self._value = value
+        self.feature_state_value = value
 
     def get_value(self, identity_id: typing.Union[int, str] = None) -> typing.Any:
         """
@@ -56,7 +56,7 @@ class FeatureStateModel:
         """
         if identity_id and len(self.multivariate_feature_state_values) > 0:
             return self._get_multivariate_value(identity_id)
-        return self._value
+        return self.feature_state_value
 
     def _get_multivariate_value(
         self, identity_id: typing.Union[int, str]
@@ -83,4 +83,4 @@ class FeatureStateModel:
 
         # default to return the control value if no MV values found, although this
         # should never happen
-        return self._value
+        return self.feature_state_value

--- a/tests/unit/features/test_schemas.py
+++ b/tests/unit/features/test_schemas.py
@@ -1,5 +1,6 @@
 import pytest
 
+from flag_engine.features.models import FeatureModel, FeatureStateModel
 from flag_engine.features.schemas import (
     FeatureStateSchema,
     MultivariateFeatureOptionSchema,
@@ -57,3 +58,14 @@ def test_can_dump_featurestate_schema_without_mvfs(feature_1):
     ).dump(raw_data)
     # Then
     assert raw_data["feature_state_value"] == dumped_data["feature_state_value"]
+
+
+def test_dumping_feature_state_model_returns_dict_with_feature_state_value():
+    # Given
+    feature = FeatureModel(id=1, name="test_feature", type="STANDARD")
+    fs_value = "some_value"
+    fs_model = FeatureStateModel(feature=feature, enabled=True)
+    # When
+    fs_model.set_value(fs_value)
+    # Then
+    assert FeatureStateSchema().dump(fs_model)["feature_state_value"] == fs_value


### PR DESCRIPTION
I figured out two ways of doing this
1. was to convert `feature_state_value` to Method field
on the schema and do serialize/deserialize madness with checks like if
it's a dict or if it's a model
2. Was to convert the private `_value to` `feature_state_value` which
looks more simple and idiomatic to me

That being said, I understand that this is not the perfect solution, let me know what do you think? 