### PR TITLE
Remove webhooks from _INTEGRATION_ATTS

### DIFF
--- a/flag_engine/environments/models.py
+++ b/flag_engine/environments/models.py
@@ -53,7 +53,6 @@ class EnvironmentModel:
         "mixpanel_config",
         "heap_config",
         "dynatrace_config",
-        "webhooks",
     ]
 
     @property


### PR DESCRIPTION
Fixes errors in lambda logs: 

```
AttributeError: 'list' object has no attribute 'base_url'
Traceback (most recent call last):
  File "/var/task/src/utils/response.py", line 61, in handler_with_options
    return handler(event, context)
  File "/var/task/src/handlers.py", line 73, in identities
    if response.environment_model.integrations_data:
  File "/var/task/flag_engine/environments/models.py", line 79, in integrations_data
    "base_url": integration_config.base_url,
```