### PR TITLE
Feat(identity/get_hash_key): Add method to help generate consistent mv values 

### DIFF
--- a/flag_engine/environments/models.py
+++ b/flag_engine/environments/models.py
@@ -39,6 +39,7 @@ class EnvironmentModel:
     feature_states: typing.List[FeatureStateModel] = field(default_factory=list)
     allow_client_traits: bool = True
     updated_at: datetime = field(default_factory=utcnow_with_tz)
+    use_mv_v2_evaluation: bool = False
 
     amplitude_config: IntegrationModel = None
     segment_config: IntegrationModel = None

--- a/flag_engine/environments/schemas.py
+++ b/flag_engine/environments/schemas.py
@@ -41,6 +41,7 @@ class BaseEnvironmentSchema(Schema):
     allow_client_traits = fields.Bool(required=False, default=True)
     updated_at = fields.DateTime()
     hide_disabled_flags = fields.Bool(required=False, allow_none=True)
+    use_mv_v2_evaluation = fields.Bool(required=False, default=False)
 
     segment_config = fields.Nested(IntegrationSchema, required=False, allow_none=True)
     heap_config = fields.Nested(IntegrationSchema, required=False, allow_none=True)

--- a/flag_engine/identities/models.py
+++ b/flag_engine/identities/models.py
@@ -28,6 +28,9 @@ class IdentityModel:
     def generate_composite_key(env_key: str, identifier: str) -> str:
         return f"{env_key}_{identifier}"
 
+    def get_hash_key(self, use_mv_v2_evaluation: bool) -> str:
+        return self.composite_key if use_mv_v2_evaluation else self.identifier
+
     def update_traits(
         self, traits: typing.List[TraitModel]
     ) -> typing.Tuple[typing.List[TraitModel], bool]:

--- a/tests/unit/identities/test_identities_models.py
+++ b/tests/unit/identities/test_identities_models.py
@@ -140,3 +140,19 @@ def test_prune_features_only_keeps_valid_features(
 
     # Then
     assert identity.identity_features == [feature_state_1]
+
+
+def test_get_hash_key_with_use_mv_v2_evaluation_enabled(identity):
+    # Given
+    use_mv_v2_evaluations = True
+
+    # When/ Then
+    assert identity.get_hash_key(use_mv_v2_evaluations) == identity.composite_key
+
+
+def test_get_hash_key_with_use_mv_v2_evaluation_disabled(identity):
+    # Given
+    use_mv_v2_evaluations = False
+
+    # When/ Then
+    assert identity.get_hash_key(use_mv_v2_evaluations) == identity.identifier


### PR DESCRIPTION
In order to support consistent multivariate evaluation across sdk
in both server and client side mode, we need a consistent key to generate
the hash `get_hash_key` returns that value based on `use_mv_v2_evaluation`
setting on environment