### PR TITLE
Fix regex evaluations for non string trait values

### DIFF
--- a/flag_engine/segments/models.py
+++ b/flag_engine/segments/models.py
@@ -56,7 +56,10 @@ class SegmentConditionModel:
         return self.value not in trait_value
 
     def evaluate_regex(self, trait_value: str) -> bool:
-        return re.compile(str(self.value)).match(str(trait_value)) is not None
+        return (
+            trait_value is not None
+            and re.compile(str(self.value)).match(str(trait_value)) is not None
+        )
 
     def evaluate_modulo(self, trait_value: typing.Union[str, int, float, bool]) -> bool:
         if type(trait_value) not in (int, float):

--- a/flag_engine/segments/models.py
+++ b/flag_engine/segments/models.py
@@ -56,7 +56,7 @@ class SegmentConditionModel:
         return self.value not in trait_value
 
     def evaluate_regex(self, trait_value: str) -> bool:
-        return re.compile(str(self.value)).match(trait_value) is not None
+        return re.compile(str(self.value)).match(str(trait_value)) is not None
 
     def evaluate_modulo(self, trait_value: typing.Union[str, int, float, bool]) -> bool:
         if type(trait_value) not in (int, float):

--- a/tests/unit/segments/test_segments_models.py
+++ b/tests/unit/segments/test_segments_models.py
@@ -60,6 +60,8 @@ from flag_engine.segments.models import SegmentConditionModel, SegmentRuleModel
         (constants.REGEX, "foo", r"[a-z]+", True),
         (constants.REGEX, "FOO", r"[a-z]+", False),
         (constants.REGEX, "1.2.3", r"\d", True),
+        (constants.REGEX, 1, r"\d", True),
+        (constants.REGEX, None, r"[a-z]", False),
         (constants.IN, "foo", "", False),
         (constants.IN, "foo", "foo, bar", True),
         (constants.IN, "foo", "foo", True),


### PR DESCRIPTION
Fixes issue caused when trying to evaluate regex segment condition against a non-string trait value. 