### PR TITLE
Update feature state version logic

### DIFF
--- a/flag_engine/api/fields.py
+++ b/flag_engine/api/fields.py
@@ -42,10 +42,7 @@ class DjangoFeatureStatesRelatedManagerField(DjangoRelatedManagerField):
                 continue
 
             existing_feature_state = features_map.get(fs.feature_id)
-            if (
-                not existing_feature_state
-                or fs.version > existing_feature_state.version
-            ):
+            if not existing_feature_state or fs > existing_feature_state:
                 features_map[fs.feature_id] = fs
 
         return list(features_map.values())

--- a/flag_engine/api/schemas.py
+++ b/flag_engine/api/schemas.py
@@ -96,7 +96,7 @@ class DjangoSegmentSchema(BaseSegmentSchema):
 
                 existing_feature_state = feature_states.get(feature_state.feature_id)
                 if not existing_feature_state or (
-                    feature_state.version > existing_feature_state.version
+                    feature_state > existing_feature_state
                 ):
                     feature_states[feature_state.feature_id] = feature_state
         return self.feature_state_schema.dump(list(feature_states.values()), many=True)

--- a/tests/mock_django_classes.py
+++ b/tests/mock_django_classes.py
@@ -1,6 +1,7 @@
 import typing
 from dataclasses import dataclass, field
 from datetime import datetime
+from unittest.mock import MagicMock
 
 from flag_engine.utils.datetime import utcnow_with_tz
 
@@ -162,6 +163,7 @@ class DjangoFeatureState:
         ] = None,
         version: int = 1,
         live_from: datetime = None,
+        gt_mock: MagicMock = MagicMock(),
     ):
         self.id = id
         self.feature_segment_id = getattr(feature_segment, "id", None)
@@ -178,6 +180,17 @@ class DjangoFeatureState:
         )
         self.version = version
         self.live_from = live_from or utcnow_with_tz()
+        self.gt_mock = gt_mock
+
+    def __gt__(self, other: "DjangoFeatureState"):
+        """
+        This is a workaround for now to avoid reimplementing the __gt__ method from the
+        FeatureState class in the django application.
+        # TODO: remove this logic from the engine and move it to the django repo.
+        """
+        if self.gt_mock is None:
+            raise NotImplementedError()
+        return self.gt_mock(self, other)
 
     def get_feature_state_value(self):
         return self.value
@@ -192,6 +205,17 @@ class DjangoFeatureState:
             self.version is not None
             and self.live_from is not None
             and self.live_from <= utcnow_with_tz()
+        )
+
+    def is_more_recent_live_from(self, other: "DjangoFeatureState") -> bool:
+        return (
+            (
+                self.live_from is not None
+                and other.live_from is not None
+                and (self.live_from > other.live_from)
+            )
+            or self.live_from is not None
+            and other.live_from is None
         )
 
 

--- a/tests/mock_django_classes.py
+++ b/tests/mock_django_classes.py
@@ -207,17 +207,6 @@ class DjangoFeatureState:
             and self.live_from <= utcnow_with_tz()
         )
 
-    def is_more_recent_live_from(self, other: "DjangoFeatureState") -> bool:
-        return (
-            (
-                self.live_from is not None
-                and other.live_from is not None
-                and (self.live_from > other.live_from)
-            )
-            or self.live_from is not None
-            and other.live_from is None
-        )
-
 
 @dataclass
 class DjangoFeatureStateRelatedManager:

--- a/tests/unit/api/test_fields.py
+++ b/tests/unit/api/test_fields.py
@@ -95,7 +95,6 @@ def test_django_feature_state_related_manager_field_serialize_discards_old_versi
     # and which has some 'feature states' associated with it in the way that you'd
     # expect a django object to. Each feature state associated with the same feature
     # but with incrementing version numbers.
-    feature_id = 1
     yesterday = utcnow_with_tz() - timedelta(days=1)
 
     def gt_mock_side_effect(first, second):

--- a/tests/unit/api/test_fields.py
+++ b/tests/unit/api/test_fields.py
@@ -4,12 +4,14 @@ from unittest import mock
 import pytest
 from marshmallow import fields
 
+from flag_engine.features.constants import STANDARD
 from flag_engine.utils.datetime import utcnow_with_tz
 from flag_engine.api.fields import (
     APITraitValueField,
     DjangoFeatureStatesRelatedManagerField,
     DjangoRelatedManagerField,
 )
+from tests.mock_django_classes import DjangoFeatureState, DjangoFeature
 
 
 @pytest.mark.parametrize(
@@ -82,7 +84,9 @@ def test_django_related_manager_field_uses_filter_function_as_provided():
     assert serialized_data == [3, 4]
 
 
-def test_django_feature_state_related_manager_field_serialize_discards_old_versions():
+def test_django_feature_state_related_manager_field_serialize_discards_old_versions(
+    django_project,
+):
     # Given
     # a mock object to serialize
     attribute_name = "feature_states"
@@ -93,10 +97,29 @@ def test_django_feature_state_related_manager_field_serialize_discards_old_versi
     # but with incrementing version numbers.
     feature_id = 1
     yesterday = utcnow_with_tz() - timedelta(days=1)
-    feature_states = [
-        mock.MagicMock(id=i, feature_id=feature_id, version=i, live_from=yesterday)
-        for i in (1, 2, 3, 4, 5)
-    ]
+
+    def gt_mock_side_effect(first, second):
+        # Simplified version of FeatureState.__gt__ from the django project.
+        return first.live_from < utcnow_with_tz() and (
+            first.live_from > second.live_from or first.version > second.version
+        )
+
+    django_feature = DjangoFeature(
+        id=1, name="test_feature", project=django_project, type=STANDARD
+    )
+
+    feature_states = []
+    for i in range(1, 6):
+        mock_fs = DjangoFeatureState(
+            id=i,
+            feature=django_feature,
+            version=i,
+            live_from=yesterday,
+            enabled=True,
+            gt_mock=mock.MagicMock(side_effect=gt_mock_side_effect),
+        )
+        feature_states.append(mock_fs)
+
     getattr(object_to_serialize, attribute_name).all.return_value = feature_states
 
     # and a filter function which will filter out the last feature state based on it's


### PR DESCRIPTION
This PR forces the serialization of environment / identity documents to correctly use the `__gt__` method on the FeatureState class vs implementing the logic separately here. 