### PR TITLE
feat: add `Project.server_key_only_feature_ids`

### DIFF
--- a/flag_engine/api/schemas.py
+++ b/flag_engine/api/schemas.py
@@ -130,6 +130,9 @@ class DjangoProjectSchema(BaseProjectSchema):
     segments = DjangoRelatedManagerField(
         fields.Nested(DjangoSegmentSchema), required=False, dump_only=True
     )
+    server_key_only_feature_ids = fields.List(
+        fields.Int(), required=False, dump_only=True
+    )
 
 
 class DjangoEnvironmentSchema(BaseEnvironmentSchema):

--- a/flag_engine/projects/models.py
+++ b/flag_engine/projects/models.py
@@ -13,3 +13,4 @@ class ProjectModel:
     hide_disabled_flags: bool
     segments: typing.List[SegmentModel] = field(default_factory=list)
     enable_realtime_updates: bool = False
+    server_key_only_feature_ids: typing.List[int] = field(default_factory=list)

--- a/flag_engine/projects/schemas.py
+++ b/flag_engine/projects/schemas.py
@@ -16,6 +16,7 @@ class BaseProjectSchema(Schema):
 
 class ProjectSchema(LoadToModelMixin, BaseProjectSchema):
     segments = fields.List(fields.Nested(SegmentSchema), required=False)
+    server_key_only_feature_ids = fields.List(fields.Int(), required=False)
 
     class Meta:
         unknown = EXCLUDE

--- a/tests/unit/api/test_document_builders.py
+++ b/tests/unit/api/test_document_builders.py
@@ -14,6 +14,7 @@ from tests.mock_django_classes import (
     DjangoFeature,
     DjangoFeatureState,
     DjangoIdentity,
+    DjangoProject,
 )
 
 
@@ -80,6 +81,25 @@ def test_build_environment_document(
     assert environment_document["webhook_config"] is not None
     assert environment_document["webhook_config"]["url"] == django_webhook.url
     assert environment_document["webhook_config"]["secret"] == django_webhook.secret
+
+
+def test_build_environment_document__project_has_server_key_only_feature_ids__return_expected(
+    django_environment: DjangoEnvironment,
+    django_project: DjangoProject,
+    django_enabled_feature_state: DjangoFeatureState,
+) -> None:
+    # Given
+    expected_server_key_only_feature_ids = [django_enabled_feature_state.feature.id]
+    django_project.server_key_only_feature_ids = expected_server_key_only_feature_ids
+
+    # When
+    environment_document = build_environment_document(django_environment)
+
+    # Then
+    assert (
+        environment_document["project"]["server_key_only_feature_ids"]
+        == expected_server_key_only_feature_ids
+    )
 
 
 def test_build_environment_api_key_document(django_environment_api_key):

--- a/tests/unit/environments/test_environments_builders.py
+++ b/tests/unit/environments/test_environments_builders.py
@@ -83,6 +83,42 @@ def test_build_environment_model_with_name():
     assert environment_model.name == environment_name
 
 
+def test_build_environment_model__project_has_server_key_only_feature_ids__return_expected() -> (
+    None
+):
+    # Given
+    expected_server_key_only_feature_ids = [1]
+    environment_name = "some_environment"
+    environment_dict = {
+        "id": 1,
+        "api_key": "api-key",
+        "name": environment_name,
+        "project": {
+            "id": 1,
+            "name": "test project",
+            "organisation": {
+                "id": 1,
+                "name": "Test org",
+                "stop_serving_flags": False,
+                "persist_trait_data": True,
+                "feature_analytics": True,
+            },
+            "hide_disabled_flags": False,
+            "server_key_only_feature_ids": expected_server_key_only_feature_ids,
+        },
+        "feature_states": [],
+    }
+
+    # When
+    environment_model = build_environment_model(environment_dict)
+
+    # Then
+    assert (
+        environment_model.project.server_key_only_feature_ids
+        == expected_server_key_only_feature_ids
+    )
+
+
 def test_get_flags_for_environment_returns_feature_states_for_environment_dictionary():
     # Given
     # some variables for use later


### PR DESCRIPTION
This PR adds `Project.local_only_feature_ids` field to be able to filter out features with `local_only` flag set to True (as per https://github.com/Flagsmith/flagsmith/issues/430#issuecomment-1551644783). 