### PR TITLE
Remove dynatrace from engine integration models

### DIFF
--- a/flag_engine/environments/models.py
+++ b/flag_engine/environments/models.py
@@ -57,7 +57,6 @@ class EnvironmentModel:
 
     _INTEGRATION_ATTS = [
         "amplitude_config",
-        "dynatrace_config",
         "heap_config",
         "mixpanel_config",
         "rudderstack_config",

--- a/tests/unit/environments/test_environments_models.py
+++ b/tests/unit/environments/test_environments_models.py
@@ -73,12 +73,6 @@ def test_environment_integrations_data_returns_correct_data_when_multiple_integr
     # Given
     example_key = "some-key"
     base_url = "https://some-integration-url"
-    entity_selector = "some-entity-selector"
-    environment.dynatrace_config = IntegrationModel(
-        api_key=example_key,
-        base_url=base_url,
-        entity_selector=entity_selector,
-    )
     environment.mixpanel_config = IntegrationModel(api_key=example_key)
     environment.segment_config = IntegrationModel(
         api_key=example_key, base_url=base_url
@@ -98,11 +92,6 @@ def test_environment_integrations_data_returns_correct_data_when_multiple_integr
             "api_key": example_key,
             "base_url": base_url,
             "entity_selector": None,
-        },
-        "dynatrace_config": {
-            "api_key": example_key,
-            "base_url": base_url,
-            "entity_selector": entity_selector,
         },
     }
 


### PR DESCRIPTION
Dynatrace was added to the integration attributes in the environment model because it does technically belong to the environment in the data structure. However, it is not what we call an 'identity integration' and therefore doesn't need to be triggered by the handle_integrations logic in the edge api. 

By removing it here from the engine, it will not be included in the iterations when the handler tries to trigger all the relevant integrations. 