### PR TITLE
fix: decimal trait values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ static/
 **/staticfiles/*
 *db.sqlite3*
 venv
-.venv
+.venv*
 *.pyc
 .idea
 .vscode

--- a/flag_engine/identities/traits/models.py
+++ b/flag_engine/identities/traits/models.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from typing import Any, get_args
 
 from pydantic import BaseModel, validator
@@ -15,6 +16,8 @@ class TraitModel(BaseModel):
     def convert_trait_value(cls, value: Any) -> TraitValue:
         if isinstance(value, TRAIT_VALUE_TYPES):
             return value
+        if isinstance(value, Decimal) and not value.as_tuple().exponent:
+            return int(value)
         return str(value)
 
     class Config:

--- a/flag_engine/identities/traits/types.py
+++ b/flag_engine/identities/traits/types.py
@@ -6,8 +6,8 @@ from flag_engine.identities.traits.constants import TRAIT_STRING_VALUE_MAX_LENGT
 
 TraitValue = Union[
     None,
-    confloat(allow_inf_nan=False),
     int,
+    confloat(allow_inf_nan=False),
     bool,
     constr(max_length=TRAIT_STRING_VALUE_MAX_LENGTH),
 ]

--- a/tests/unit/identities/traits/test_models.py
+++ b/tests/unit/identities/traits/test_models.py
@@ -27,10 +27,12 @@ def test_trait_model__invalid_trait_value__raise_expected() -> None:
     [
         (Decimal("1"), 1),
         (Decimal("1.1"), 1.1),
+        ("1", 1),
+        ("1.0", 1.0),
     ],
 )
-def test_trait_model__decimal_trait_value__coerce_expected(
-    trait_value_argument: Decimal,
+def test_trait_model__trait_value__coerce_expected(
+    trait_value_argument: Union[Decimal, str],
     expected_trait_value: Union[int, float],
 ) -> None:
     # When

--- a/tests/unit/identities/traits/test_models.py
+++ b/tests/unit/identities/traits/test_models.py
@@ -1,10 +1,13 @@
+from decimal import Decimal
+from typing import Union
+
 import pytest
 from pydantic import ValidationError
 
 from flag_engine.identities.traits import models
 
 
-def test_trait_model__invalid_trait_value__raises_expected():
+def test_trait_model__invalid_trait_value__raise_expected() -> None:
     # Given
     invalid_trait_kwargs = {"trait_key": "scream", "trait_value": "A" * 2001}
 
@@ -17,3 +20,25 @@ def test_trait_model__invalid_trait_value__raises_expected():
         exc_info.value.errors()[-1]["msg"]
         == "ensure this value has at most 2000 characters"
     )
+
+
+@pytest.mark.parametrize(
+    "trait_value_argument, expected_trait_value",
+    [
+        (Decimal("1"), 1),
+        (Decimal("1.1"), 1.1),
+    ],
+)
+def test_trait_model__decimal_trait_value__coerce_expected(
+    trait_value_argument: Decimal,
+    expected_trait_value: Union[int, float],
+) -> None:
+    # When
+    trait_model = models.TraitModel(
+        trait_key="test_trait",
+        trait_value=trait_value_argument,
+    )
+
+    # Then
+    assert type(trait_model.trait_value) is type(expected_trait_value)
+    assert trait_model.trait_value == expected_trait_value


### PR DESCRIPTION
This PR fixes two issues:

1. When passing a `decimal.Decimal` as trait value, the engine will check if it's an actual integer value instead of blindly coercing to float.
2. When coercing a numeric string, the engine will try int before float.