### PR TITLE
feat: Add segment types, segment metadata, identity override segments support

### DIFF
--- a/flag_engine/segments/constants.py
+++ b/flag_engine/segments/constants.py
@@ -20,3 +20,5 @@ MODULO: ConditionOperator = "MODULO"
 IS_SET: ConditionOperator = "IS_SET"
 IS_NOT_SET: ConditionOperator = "IS_NOT_SET"
 IN: ConditionOperator = "IN"
+
+SEGMENT_IDENTIFIER_PROPERTY_NAME: str = "_$identity.identifier"

--- a/flag_engine/segments/models.py
+++ b/flag_engine/segments/models.py
@@ -5,7 +5,7 @@ from typing_extensions import Annotated
 
 from flag_engine.features.models import FeatureStateModel
 from flag_engine.segments import constants
-from flag_engine.segments.types import ConditionOperator, RuleType, SegmentType
+from flag_engine.segments.types import ConditionOperator, RuleType
 
 LaxStr = Annotated[str, BeforeValidator(lambda x: str(x))]
 
@@ -34,15 +34,9 @@ class SegmentRuleModel(BaseModel):
         }[self.type]
 
 
-class SegmentMetadata(BaseModel):
-    type: SegmentType = "SEGMENT"
-    identity_identifier: typing.Optional[str] = None
-    identity_uuid: typing.Optional[str] = None
-
-
 class SegmentModel(BaseModel):
     id: int
     name: str
     rules: typing.List[SegmentRuleModel] = Field(default_factory=list)
     feature_states: typing.List[FeatureStateModel] = Field(default_factory=list)
-    meta: typing.Optional[SegmentMetadata] = None
+    meta: typing.Optional[typing.Dict[str, str]] = None

--- a/flag_engine/segments/models.py
+++ b/flag_engine/segments/models.py
@@ -5,7 +5,7 @@ from typing_extensions import Annotated
 
 from flag_engine.features.models import FeatureStateModel
 from flag_engine.segments import constants
-from flag_engine.segments.types import ConditionOperator, RuleType
+from flag_engine.segments.types import ConditionOperator, RuleType, SegmentType
 
 LaxStr = Annotated[str, BeforeValidator(lambda x: str(x))]
 
@@ -34,8 +34,15 @@ class SegmentRuleModel(BaseModel):
         }[self.type]
 
 
+class SegmentMetadata(BaseModel):
+    type: SegmentType = "SEGMENT"
+    identity_identifier: typing.Optional[str] = None
+    identity_uuid: typing.Optional[str] = None
+
+
 class SegmentModel(BaseModel):
     id: int
     name: str
     rules: typing.List[SegmentRuleModel] = Field(default_factory=list)
     feature_states: typing.List[FeatureStateModel] = Field(default_factory=list)
+    meta: typing.Optional[SegmentMetadata] = None

--- a/flag_engine/segments/types.py
+++ b/flag_engine/segments/types.py
@@ -22,3 +22,9 @@ RuleType = Literal[
     "ANY",
     "NONE",
 ]
+
+SegmentType = Literal[
+    "SEGMENT",
+    "IDENTITY_OVERRIDE",
+    "SEGMENT_OVERRIDE",
+]

--- a/flag_engine/segments/types.py
+++ b/flag_engine/segments/types.py
@@ -22,9 +22,3 @@ RuleType = Literal[
     "ANY",
     "NONE",
 ]
-
-SegmentType = Literal[
-    "SEGMENT",
-    "IDENTITY_OVERRIDE",
-    "SEGMENT_OVERRIDE",
-]

--- a/tests/unit/segments/fixtures.py
+++ b/tests/unit/segments/fixtures.py
@@ -14,6 +14,7 @@ trait_value_2 = "12"
 trait_key_3 = "date_joined"
 trait_value_3 = "2021-01-01"
 
+identifier = "identity_1"
 
 empty_segment = SegmentModel(id=1, name="empty_segment")
 segment_single_condition = SegmentModel(
@@ -147,4 +148,24 @@ segment_conditions_and_nested_rules = SegmentModel(
             ],
         )
     ],
+)
+segment_identity_override = SegmentModel(
+    id=7,
+    name="segment_identity_override",
+    rules=[
+        SegmentRuleModel(
+            type=constants.ALL_RULE,
+            conditions=[
+                SegmentConditionModel(
+                    operator=constants.EQUAL,
+                    property_=constants.SEGMENT_IDENTIFIER_PROPERTY_NAME,
+                    value=identifier,
+                )
+            ],
+        )
+    ],
+    meta={
+        "identity_identifier": identifier,
+        "type": "IDENTITY_OVERRIDE",
+    },
 )

--- a/tests/unit/segments/test_segments_evaluator.py
+++ b/tests/unit/segments/test_segments_evaluator.py
@@ -268,7 +268,7 @@ def test_identity_in_segment_is_set_and_is_not_set(
         (constants.IN, 1, None, False),
     ),
 )
-def test_segment_condition_condition_matches_value(
+def test_segment_condition_matches_value(
     operator: ConditionOperator,
     trait_value: typing.Union[None, int, str, float],
     condition_value: object,
@@ -332,7 +332,7 @@ def test_segment_condition__unsupported_operator__return_false(
         (constants.LESS_THAN_INCLUSIVE, "1.0.1", "1.0.0:semver", False),
     ],
 )
-def test_segment_condition_condition_matches_value_for_semver(
+def test_segment_condition_matches_value_for_semver(
     operator: ConditionOperator,
     trait_value: str,
     condition_value: str,
@@ -367,7 +367,7 @@ def test_segment_condition_condition_matches_value_for_semver(
         (1, None, False),
     ],
 )
-def test_segment_condition_condition_matches_value_for_modulo(
+def test_segment_condition_matches_value_for_modulo(
     trait_value: typing.Union[int, float, str, bool],
     condition_value: typing.Optional[str],
     expected_result: bool,

--- a/tests/unit/segments/test_segments_evaluator.py
+++ b/tests/unit/segments/test_segments_evaluator.py
@@ -8,7 +8,7 @@ from flag_engine.identities.models import IdentityModel
 from flag_engine.identities.traits.models import TraitModel
 from flag_engine.segments import constants
 from flag_engine.segments.evaluator import (
-    _matches_trait_value,
+    _condition_matches_value,
     evaluate_identity_in_segment,
 )
 from flag_engine.segments.models import (
@@ -19,7 +19,9 @@ from flag_engine.segments.models import (
 from flag_engine.segments.types import ConditionOperator
 from tests.unit.segments.fixtures import (
     empty_segment,
+    identifier,
     segment_conditions_and_nested_rules,
+    segment_identity_override,
     segment_multiple_conditions_all,
     segment_multiple_conditions_any,
     segment_nested_rules,
@@ -106,6 +108,7 @@ from tests.unit.segments.fixtures import (
             ],
             True,
         ),
+        (segment_identity_override, [], True),
     ),
 )
 def test_identity_in_segment(
@@ -114,7 +117,7 @@ def test_identity_in_segment(
     expected_result: bool,
 ) -> None:
     identity = IdentityModel(
-        identifier="foo",
+        identifier=identifier,
         identity_traits=identity_traits,
         environment_api_key="api-key",
     )
@@ -265,7 +268,7 @@ def test_identity_in_segment_is_set_and_is_not_set(
         (constants.IN, 1, None, False),
     ),
 )
-def test_segment_condition_matches_trait_value(
+def test_segment_condition_condition_matches_value(
     operator: ConditionOperator,
     trait_value: typing.Union[None, int, str, float],
     condition_value: object,
@@ -279,7 +282,7 @@ def test_segment_condition_matches_trait_value(
     )
 
     # When
-    result = _matches_trait_value(segment_condition, trait_value)
+    result = _condition_matches_value(segment_condition, trait_value)
 
     # Then
     assert result == expected_result
@@ -298,7 +301,7 @@ def test_segment_condition__unsupported_operator__return_false(
     trait_value = "foo"
 
     # When
-    result = _matches_trait_value(segment_condition, trait_value)
+    result = _condition_matches_value(segment_condition, trait_value)
 
     # Then
     assert result is False
@@ -329,7 +332,7 @@ def test_segment_condition__unsupported_operator__return_false(
         (constants.LESS_THAN_INCLUSIVE, "1.0.1", "1.0.0:semver", False),
     ],
 )
-def test_segment_condition_matches_trait_value_for_semver(
+def test_segment_condition_condition_matches_value_for_semver(
     operator: ConditionOperator,
     trait_value: str,
     condition_value: str,
@@ -343,7 +346,7 @@ def test_segment_condition_matches_trait_value_for_semver(
     )
 
     # When
-    result = _matches_trait_value(segment_condition, trait_value)
+    result = _condition_matches_value(segment_condition, trait_value)
 
     # Then
     assert result == expected_result
@@ -364,7 +367,7 @@ def test_segment_condition_matches_trait_value_for_semver(
         (1, None, False),
     ],
 )
-def test_segment_condition_matches_trait_value_for_modulo(
+def test_segment_condition_condition_matches_value_for_modulo(
     trait_value: typing.Union[int, float, str, bool],
     condition_value: typing.Optional[str],
     expected_result: bool,
@@ -377,7 +380,7 @@ def test_segment_condition_matches_trait_value_for_modulo(
     )
 
     # When
-    result = _matches_trait_value(segment_condition, trait_value)
+    result = _condition_matches_value(segment_condition, trait_value)
 
     # Then
     assert result == expected_result


### PR DESCRIPTION
Closes #197.

This PR adds the following:
- `meta: dict[str, str] | None` field to the Segment model. It's intended to be used by Core and Edge API to store data specific for their Flagsmith implementations, unrelated to the engine and SDKs.
- A special `"_$identity.identifier"` string literal can be now assigned to `SegmentCondition.property_` to make the engine match segment condition rules against the identity identifier.

