### PR TITLE
ci: remove depot runner from conventional commit workflow

### DIFF
--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   conventional-commit:
     name: Conventional Commit
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Check PR Conventional Commit title
         uses: amannn/action-semantic-pull-request@v5


### PR DESCRIPTION
Removes unnecessary usage of depot runner for conventional commit validation workflow