### PR TITLE
ci: Publish a wheel, move on from deprecated `setup.py` usage

### DIFF
--- a/.github/workflows/publish-pypi-package.yml
+++ b/.github/workflows/publish-pypi-package.yml
@@ -17,7 +17,9 @@ jobs:
           fetch-depth: 0
 
       - name: Build binary wheel and a source tarball
-        run: python setup.py sdist
+        run: |
+          python -m pip install build
+          python -m build
 
       - name: Publish Package to Pypi
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
this project publishes [only source distributions](https://pypi.org/project/flagsmith-flag-engine/#files).  Publish wheels too.

(The comment in the github action promises a wheel; but a comment is not enough!)

Also switch to building distributions using `build` - direct invocation of `setup.py` is deprecated.