### PR TITLE
fix: added-none-check-in-context-matches-condition

### DIFF
--- a/flag_engine/segments/evaluator.py
+++ b/flag_engine/segments/evaluator.py
@@ -7,9 +7,7 @@ from functools import partial, wraps
 import semver
 
 from flag_engine.context.types import EvaluationContext
-from flag_engine.identities.traits.types import (
-    ContextValue,
-)
+from flag_engine.identities.traits.types import ContextValue
 from flag_engine.segments import constants
 from flag_engine.segments.models import (
     SegmentConditionModel,

--- a/flag_engine/segments/evaluator.py
+++ b/flag_engine/segments/evaluator.py
@@ -9,7 +9,6 @@ import semver
 from flag_engine.context.types import EvaluationContext
 from flag_engine.identities.traits.types import (
     ContextValue,
-    map_any_value_to_trait_value,
 )
 from flag_engine.segments import constants
 from flag_engine.segments.models import (

--- a/flag_engine/segments/evaluator.py
+++ b/flag_engine/segments/evaluator.py
@@ -7,7 +7,10 @@ from functools import partial, wraps
 import semver
 
 from flag_engine.context.types import EvaluationContext
-from flag_engine.identities.traits.types import ContextValue
+from flag_engine.identities.traits.types import (
+    ContextValue,
+    map_any_value_to_trait_value,
+)
 from flag_engine.segments import constants
 from flag_engine.segments.models import (
     SegmentConditionModel,
@@ -100,7 +103,11 @@ def context_matches_condition(
     if condition.operator == constants.IS_SET:
         return context_value is not None
 
-    return _matches_context_value(condition, context_value) if context_value else False
+    return (
+        _matches_context_value(condition, context_value)
+        if context_value is not None
+        else False
+    )
 
 
 def _get_trait(context: EvaluationContext, trait_key: str) -> ContextValue:

--- a/tests/unit/segments/test_segments_evaluator.py
+++ b/tests/unit/segments/test_segments_evaluator.py
@@ -528,7 +528,7 @@ def test_segment_condition_matches_context_value_for_semver(
         ),
     ),
 )
-def test_context_matches_condition_evaluates_with_correct_casting(
+def test_context_matches_condition(
     context: EvaluationContext,
     condition: SegmentConditionModel,
     segment_key: str,


### PR DESCRIPTION
Check before calling `matches_context_value` was returning falsy with context values `false`