### PR TITLE
feat: apply rules based on type instead of hardcoded all

### DIFF
--- a/flag_engine/segments/evaluator.py
+++ b/flag_engine/segments/evaluator.py
@@ -249,14 +249,21 @@ def context_matches_rule(
         else True
     )
 
-    return matches_conditions and all(
-        context_matches_rule(
-            context=context,
-            rule=rule,
-            segment_key=segment_key,
+    matches_rules = (
+        get_matching_function(rule["type"])(
+            [
+                context_matches_rule(
+                    context=context,
+                    rule=sub_rule,
+                    segment_key=segment_key,
+                )
+                for sub_rule in rules
+            ]
         )
-        for rule in rule.get("rules") or []
+        if (rules := rule.get("rules"))
+        else True
     )
+    return matches_conditions and matches_rules
 
 
 def context_matches_condition(

--- a/flag_engine/segments/evaluator.py
+++ b/flag_engine/segments/evaluator.py
@@ -236,14 +236,12 @@ def context_matches_rule(
 ) -> bool:
     matches_conditions = (
         get_matching_function(rule["type"])(
-            [
-                context_matches_condition(
-                    context=context,
-                    condition=condition,
-                    segment_key=segment_key,
-                )
-                for condition in conditions
-            ]
+            context_matches_condition(
+                context=context,
+                condition=condition,
+                segment_key=segment_key,
+            )
+            for condition in conditions
         )
         if (conditions := rule.get("conditions"))
         else True
@@ -251,14 +249,12 @@ def context_matches_rule(
 
     matches_rules = (
         get_matching_function(rule["type"])(
-            [
-                context_matches_rule(
-                    context=context,
-                    rule=sub_rule,
-                    segment_key=segment_key,
-                )
-                for sub_rule in rules
-            ]
+            context_matches_rule(
+                context=context,
+                rule=sub_rule,
+                segment_key=segment_key,
+            )
+            for sub_rule in rules
         )
         if (rules := rule.get("rules"))
         else True

--- a/tests/unit/segments/fixtures.py
+++ b/tests/unit/segments/fixtures.py
@@ -110,6 +110,48 @@ segment_nested_rules: SegmentContext = {
     ],
 }
 
+segment_any_with_nested_all_groups: SegmentContext = {
+    "key": "7",
+    "name": "segment_any_with_nested_all_groups",
+    "rules": [
+        {
+            "type": constants.ALL_RULE,
+            "rules": [
+                {
+                    "type": constants.ANY_RULE,
+                    "rules": [
+                        {
+                            "type": constants.ALL_RULE,
+                            "conditions": [
+                                {
+                                    "operator": constants.EQUAL,
+                                    "property": trait_key_1,
+                                    "value": trait_value_1,
+                                },
+                                {
+                                    "operator": constants.EQUAL,
+                                    "property": trait_key_2,
+                                    "value": trait_value_2,
+                                },
+                            ],
+                        },
+                        {
+                            "type": constants.ALL_RULE,
+                            "conditions": [
+                                {
+                                    "operator": constants.EQUAL,
+                                    "property": trait_key_3,
+                                    "value": trait_value_3,
+                                },
+                            ],
+                        },
+                    ],
+                }
+            ],
+        }
+    ],
+}
+
 segment_conditions_and_nested_rules: SegmentContext = {
     "key": "6",
     "name": "segment_multiple_conditions_all_and_nested_rules",

--- a/tests/unit/segments/fixtures.py
+++ b/tests/unit/segments/fixtures.py
@@ -110,47 +110,6 @@ segment_nested_rules: SegmentContext = {
     ],
 }
 
-segment_any_with_nested_all_groups: SegmentContext = {
-    "key": "7",
-    "name": "segment_any_with_nested_all_groups",
-    "rules": [
-        {
-            "type": constants.ALL_RULE,
-            "rules": [
-                {
-                    "type": constants.ANY_RULE,
-                    "rules": [
-                        {
-                            "type": constants.ALL_RULE,
-                            "conditions": [
-                                {
-                                    "operator": constants.EQUAL,
-                                    "property": trait_key_1,
-                                    "value": trait_value_1,
-                                },
-                                {
-                                    "operator": constants.EQUAL,
-                                    "property": trait_key_2,
-                                    "value": trait_value_2,
-                                },
-                            ],
-                        },
-                        {
-                            "type": constants.ALL_RULE,
-                            "conditions": [
-                                {
-                                    "operator": constants.EQUAL,
-                                    "property": trait_key_3,
-                                    "value": trait_value_3,
-                                },
-                            ],
-                        },
-                    ],
-                }
-            ],
-        }
-    ],
-}
 
 segment_conditions_and_nested_rules: SegmentContext = {
     "key": "6",

--- a/tests/unit/segments/test_segments_evaluator.py
+++ b/tests/unit/segments/test_segments_evaluator.py
@@ -23,7 +23,6 @@ from flag_engine.segments.evaluator import (
 from flag_engine.segments.types import ConditionOperator
 from tests.unit.segments.fixtures import (
     empty_segment,
-    segment_any_with_nested_all_groups,
     segment_conditions_and_nested_rules,
     segment_multiple_conditions_all,
     segment_multiple_conditions_any,
@@ -212,49 +211,6 @@ from tests.unit.segments.fixtures import (
                 },
             },
             True,
-        ),
-        (
-            segment_any_with_nested_all_groups,
-            {
-                "environment": {"key": "key", "name": "Environment"},
-                "identity": {
-                    "identifier": "foo",
-                    "key": "key_foo",
-                    "traits": {
-                        trait_key_1: trait_value_1,
-                        trait_key_2: trait_value_2,
-                    },
-                },
-            },
-            True,
-        ),
-        (
-            segment_any_with_nested_all_groups,
-            {
-                "environment": {"key": "key", "name": "Environment"},
-                "identity": {
-                    "identifier": "foo",
-                    "key": "key_foo",
-                    "traits": {
-                        trait_key_3: trait_value_3,
-                    },
-                },
-            },
-            True,
-        ),
-        (
-            segment_any_with_nested_all_groups,
-            {
-                "environment": {"key": "key", "name": "Environment"},
-                "identity": {
-                    "identifier": "foo",
-                    "key": "key_foo",
-                    "traits": {
-                        trait_key_1: trait_value_1,
-                    },
-                },
-            },
-            False,
         ),
     ),
 )

--- a/tests/unit/segments/test_segments_evaluator.py
+++ b/tests/unit/segments/test_segments_evaluator.py
@@ -23,6 +23,7 @@ from flag_engine.segments.evaluator import (
 from flag_engine.segments.types import ConditionOperator
 from tests.unit.segments.fixtures import (
     empty_segment,
+    segment_any_with_nested_all_groups,
     segment_conditions_and_nested_rules,
     segment_multiple_conditions_all,
     segment_multiple_conditions_any,
@@ -211,6 +212,49 @@ from tests.unit.segments.fixtures import (
                 },
             },
             True,
+        ),
+        (
+            segment_any_with_nested_all_groups,
+            {
+                "environment": {"key": "key", "name": "Environment"},
+                "identity": {
+                    "identifier": "foo",
+                    "key": "key_foo",
+                    "traits": {
+                        trait_key_1: trait_value_1,
+                        trait_key_2: trait_value_2,
+                    },
+                },
+            },
+            True,
+        ),
+        (
+            segment_any_with_nested_all_groups,
+            {
+                "environment": {"key": "key", "name": "Environment"},
+                "identity": {
+                    "identifier": "foo",
+                    "key": "key_foo",
+                    "traits": {
+                        trait_key_3: trait_value_3,
+                    },
+                },
+            },
+            True,
+        ),
+        (
+            segment_any_with_nested_all_groups,
+            {
+                "environment": {"key": "key", "name": "Environment"},
+                "identity": {
+                    "identifier": "foo",
+                    "key": "key_foo",
+                    "traits": {
+                        trait_key_1: trait_value_1,
+                    },
+                },
+            },
+            False,
         ),
     ),
 )


### PR DESCRIPTION
Apply the rule's matching function (ALL/ANY/NONE) to sub-rules on top of conditions. Sub-rules were always evaluated with  `all()` independently of the rule's type, making it impossible to evaluate OR between groups of AND conditions.

This unlocks `(environment_name=env_1 and some_trait=foo) or (environment_name=env_2 and some_trait=bar) or (environment_name=env_3 and some_trait=baz)` without affecting existing segments and their behavior.