### PR TITLE
ci: added renovate config

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "tests/engine_tests/engine-test-data"]
 	path = tests/engine_tests/engine-test-data
 	url = https://github.com/flagsmith/engine-test-data.git
-	tag = v3.6.0
+	branch = v3.6.0

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: sync-engine-test-data
+
+sync-engine-test-data:
+	cd tests/engine_tests/engine-test-data && git fetch --tags && git checkout $$(git config -f ../../../.gitmodules submodule.tests/engine_tests/engine-test-data.branch)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ source .venv/bin/activate
 python -m pip install -r requirements-dev.txt
 ```
 
+## Syncing engine-test-data
+
+The engine-test-data submodule is pinned to a specific tag. To sync it locally:
+
+```bash
+make sync-engine-test-data
+```
+
 ## Design
 
 - Marshmallow Schemas

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "git-submodules": {
+    "enabled": true
+  },
+  "pip-compile": {
+    "enabled": true,
+    "fileMatch": ["requirements\\.in$", "requirements-dev\\.in$"]
+  }
+}


### PR DESCRIPTION
Setup renovate based on `flagsmith-common` configuration.

It might need to configure renovate with this repo.