### PR TITLE
ci: reduce renovate watchlist

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,29 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", ":semanticCommitScopeDisabled"],
+  "ignorePresets": [":semanticPrefixFixDepsChoreOthers"],
+  "semanticCommitType": "deps",
   "git-submodules": {
     "enabled": true
   },
-  "pip-compile": {
-    "enabled": true,
-    "fileMatch": ["requirements\\.in$", "requirements-dev\\.in$"]
-  }
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "digest",
+        "pin",
+        "rollback",
+        "bump",
+        "replacement",
+        "lockFileMaintenance"
+      ],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["git-submodules", "pip_requirements", "pip-compile", "pep621", "poetry"],
+      "enabled": true
+    }
+  ]
 }


### PR DESCRIPTION
### Summary
  - Migrates from Dependabot to Renovate, matching the flagsmith-common commit style (`deps: prefix`, `:semanticCommitScopeDisabled`).
  - First `packageRule` disables all routine updates by listing every `matchUpdateTypes` except vulnerabilityAlerts — CVE PRs still flow through for all dependencies.
  - Second `packageRule` re-enables git-submodules and all pip managers (`pip_requirements`, `pip-compile`, `pep621`, `poetry`), matching the existing Dependabot behavior of bumping pip dependencies.
  - github-actions manager stays disabled — Dependabot wasn't managing those either.
  - git-submodules enabled at top level so Renovate tracks engine-test-data tag updates.

###   Test plan
  - Renovate dashboard issue shows pip dependencies and engine-test-data submodule as detected, but no github-actions PRs.
  - Confirm Dependabot security updates remain enabled at the repo level so the CVE path stays redundant-by-design.